### PR TITLE
Camera Refactoring

### DIFF
--- a/Photo Categorizer/Base.lproj/Main.storyboard
+++ b/Photo Categorizer/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lap-dW-zf0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lap-dW-zf0">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -491,6 +491,13 @@ Upgrade now to get...
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <activityIndicatorView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="DGP-BS-edi">
+                                <rect key="frame" x="169" y="347" width="37" height="37"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="37" id="E5f-tf-5ML"/>
+                                    <constraint firstAttribute="height" constant="37" id="NWe-7D-5FD"/>
+                                </constraints>
+                            </activityIndicatorView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tb0-ui-As2">
                                 <rect key="frame" x="157.5" y="577" width="60" height="60"/>
                                 <color key="backgroundColor" red="1" green="0.0" blue="0.50196081400000003" alpha="0.0" colorSpace="calibratedRGB"/>
@@ -550,6 +557,8 @@ Upgrade now to get...
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="esF-Y7-iyc" firstAttribute="top" secondItem="8KK-pC-YUY" secondAttribute="top" constant="12" id="7wb-GJ-lvO"/>
+                            <constraint firstItem="DGP-BS-edi" firstAttribute="centerY" secondItem="8KK-pC-YUY" secondAttribute="centerY" id="CST-uL-9x0"/>
+                            <constraint firstItem="DGP-BS-edi" firstAttribute="centerX" secondItem="8KK-pC-YUY" secondAttribute="centerX" id="FPc-47-ryT"/>
                             <constraint firstItem="R4A-b6-s7P" firstAttribute="leading" secondItem="8KK-pC-YUY" secondAttribute="leading" constant="20" id="GSV-Og-Mcz"/>
                             <constraint firstAttribute="bottom" secondItem="Tb0-ui-As2" secondAttribute="bottom" constant="30" id="J8b-QM-CNw"/>
                             <constraint firstItem="nmT-RO-OeC" firstAttribute="leading" secondItem="8KK-pC-YUY" secondAttribute="leading" constant="20" id="JSE-9C-SRD"/>
@@ -566,6 +575,7 @@ Upgrade now to get...
                         </connections>
                     </view>
                     <connections>
+                        <outlet property="activityIndicator" destination="DGP-BS-edi" id="RgQ-0P-iMI"/>
                         <outlet property="back" destination="esF-Y7-iyc" id="ttb-Ew-eo9"/>
                         <outlet property="cameraButton" destination="Tb0-ui-As2" id="3gk-fC-Uqa"/>
                         <outlet property="flip" destination="RGi-Xy-88h" id="vdz-B1-q1F"/>
@@ -605,12 +615,12 @@ Upgrade now to get...
         <image name="back" width="2000" height="2000"/>
         <image name="button-shutter" width="122" height="122"/>
         <image name="cancel" width="512" height="512"/>
-        <image name="crown" width="186" height="108.23999786376953"/>
-        <image name="download" width="28.799999237060547" height="28.799999237060547"/>
+        <image name="crown" width="775" height="451"/>
+        <image name="download" width="40" height="40"/>
         <image name="edit" width="128" height="128"/>
-        <image name="plus" width="48" height="48"/>
-        <image name="switch" width="384" height="384"/>
-        <image name="trash" width="7.8126001358032227" height="7.8126001358032227"/>
+        <image name="plus" width="50" height="50"/>
+        <image name="switch" width="512" height="512"/>
+        <image name="trash" width="100" height="100"/>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="RsU-We-wle"/>

--- a/Photo Categorizer/CategoryAlbumViewController.swift
+++ b/Photo Categorizer/CategoryAlbumViewController.swift
@@ -29,7 +29,13 @@ func getImages() {
     for (indexOfImage, i) in imagesArray.enumerated() {
         let indexOfCategory: Int = categories.index(of: i.category!)!
         if let imageData = i.image {
-            categoriesImageArray[indexOfCategory].append(resizeImage(image: UIImage(data: imageData as Data,scale:0.01)!, newWidth: 150))
+
+            guard let image = UIImage(data: imageData as Data, scale: 0.01) else {
+                print("Unable to get image")
+                return
+            }
+
+            categoriesImageArray[indexOfCategory].append(image.resizeImage(newWidth: 150))
             categoriesIndexArray[indexOfCategory].append(indexOfImage)
             ImagesIDArray[indexOfCategory].append(Int(i.id))
         }

--- a/Photo Categorizer/Extensions/UIImage+Extension.swift
+++ b/Photo Categorizer/Extensions/UIImage+Extension.swift
@@ -1,0 +1,28 @@
+//
+//  UIImage+Extension.swift
+//  Photo_Categorizer
+//
+//  Created by Ismael Zavala on 8/14/19.
+//  Copyright © 2019 Johansson. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIImage {
+    public func resizeImage(newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+
+        UIGraphicsBeginImageContext(CGSize(width: newWidth, height: newHeight))
+
+        self.draw(in: CGRect(x: 0, y: 0,width: newWidth, height: newHeight))
+        guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else {
+            print("Unable to get new image")
+            return UIImage()
+        }
+        UIGraphicsEndImageContext()
+
+        return newImage
+    }
+}

--- a/Photo Categorizer/HomeViewController.swift
+++ b/Photo Categorizer/HomeViewController.swift
@@ -29,19 +29,6 @@ let banner1 = GADBannerView(adSize: kGADAdSizeBanner)
 
 private var firstLaunch : Bool = false
 
-public func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
-    let scale = newWidth / image.size.width
-    let newHeight = image.size.height * scale
-    
-    UIGraphicsBeginImageContext(CGSize(width: newWidth, height: newHeight))
-    
-    image.draw(in: CGRect(x: 0, y: 0,width: newWidth, height: newHeight))
-    let newImage = UIGraphicsGetImageFromCurrentImageContext()
-    UIGraphicsEndImageContext()
-    
-    return newImage!
-}
-
 class HomeViewController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, GADBannerViewDelegate {
     
     @IBOutlet var homeCollectionView: UICollectionView!
@@ -135,7 +122,7 @@ class HomeViewController: UIViewController, UICollectionViewDelegate, UICollecti
         
         if indexPath[1] < (categories.count) {
             if categoriesIndexArray[indexPath[1]].last != nil {
-                cell.thumbnailImage.image = resizeImage(image: UIImage(data: imagesArray[categoriesIndexArray[indexPath[1]].last!].image! as Data,scale:0.01)!, newWidth: 350)
+                cell.thumbnailImage.image = UIImage(data: imagesArray[categoriesIndexArray[indexPath[1]].last!].image! as Data,scale:0.01)!
                 cell.edit.isHidden = false
                 cell.CategoryName.text = categories[indexPath[1]]
             } else {

--- a/Photo Categorizer/ShowFullViewController.swift
+++ b/Photo Categorizer/ShowFullViewController.swift
@@ -122,18 +122,15 @@ class ShowFullViewController: UIViewController, UIScrollViewDelegate, GADBannerV
     }
     
     @objc func image(_ image: UIImage, didFinishSavingWithError error: NSError?, contextInfo: UnsafeRawPointer) {
-        if let error = error {
-            // we got back an error!
-            let alert = UIAlertController(title: "An error occured", message: "Your image was not saved to your camera roll.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "Okay", style: .default, handler: nil)
-            alert.addAction(okAction)
-            self.present(alert, animated: true, completion: nil)
-        } else {
-            let alert = UIAlertController(title: "Saved", message: "Your image was saved to your camera roll.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "Okay", style: .default, handler: nil)
-            alert.addAction(okAction)
-            self.present(alert, animated: true, completion: nil)
-        }
+        // Getting alert title and message
+        let alertTitle = (error == nil) ? "Saved" : "An error occured"
+        let alertMessage = (error == nil) ? "Your image was not saved to your camera roll." : "Your image was saved to your camera roll."
+
+        // Creating and presenting alert.
+        let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "Okay", style: .default, handler: nil)
+        alert.addAction(okAction)
+        self.present(alert, animated: true, completion: nil)
     }
     
     override func didReceiveMemoryWarning() {

--- a/Photo_Categorizer.xcodeproj/project.pbxproj
+++ b/Photo_Categorizer.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3B4C39B500F53B6445CB297F /* Pods_Photo_Categorizer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01429424EED51E779CD7ED7A /* Pods_Photo_Categorizer.framework */; };
 		53B5D3A92303936C00818945 /* PersistanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B5D3A82303936B00818945 /* PersistanceService.swift */; };
+		53C67F562305074C0048B9C8 /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C67F552305074C0048B9C8 /* UIImage+Extension.swift */; };
 		E10A403822033EE7001A034F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E10A403722033EE7001A034F /* GoogleService-Info.plist */; };
 		E112198A21D9876C00E4F220 /* PremiumViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E112198921D9876C00E4F220 /* PremiumViewController.swift */; };
 		E1313DE820478186002DC39D /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1313DE720478186002DC39D /* StoreKit.framework */; };
@@ -35,6 +36,7 @@
 		01429424EED51E779CD7ED7A /* Pods_Photo_Categorizer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Photo_Categorizer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E1A218FD161AC96286810E0 /* Pods-Photo_Categorizer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Photo_Categorizer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Photo_Categorizer/Pods-Photo_Categorizer.debug.xcconfig"; sourceTree = "<group>"; };
 		53B5D3A82303936B00818945 /* PersistanceService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistanceService.swift; sourceTree = "<group>"; };
+		53C67F552305074C0048B9C8 /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		982F54091911BF69841870F2 /* Pods-Photo_Categorizer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Photo_Categorizer.release.xcconfig"; path = "Pods/Target Support Files/Pods-Photo_Categorizer/Pods-Photo_Categorizer.release.xcconfig"; sourceTree = "<group>"; };
 		E10A403722033EE7001A034F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E112198921D9876C00E4F220 /* PremiumViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumViewController.swift; sourceTree = "<group>"; };
@@ -73,6 +75,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		53C67F542305073D0048B9C8 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				53C67F552305074C0048B9C8 /* UIImage+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		CD046DA083D876F896DB26B9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,6 +134,7 @@
 		E1511D46200162F90005AE36 /* Photo Categorizer */ = {
 			isa = PBXGroup;
 			children = (
+				53C67F542305073D0048B9C8 /* Extensions */,
 				E17E4CDA21E6736D00E82FB6 /* HomeViewController.swift */,
 				E1511D5D200177B90005AE36 /* CameraViewController.swift */,
 				E1D31AD7203907250066E9A0 /* CategoryAlbumViewController.swift */,
@@ -288,6 +299,7 @@
 				E1AF3E52203BAFAC000CDF49 /* PopUpViewController.swift in Sources */,
 				E1B28D022035E7C100EA29A9 /* Images+CoreDataProperties.swift in Sources */,
 				E17E4CDB21E6736D00E82FB6 /* HomeViewController.swift in Sources */,
+				53C67F562305074C0048B9C8 /* UIImage+Extension.swift in Sources */,
 				E13DD5E721D8AE4A001F7BB6 /* IAPService.swift in Sources */,
 				E1D31AD8203907250066E9A0 /* CategoryAlbumViewController.swift in Sources */,
 				E13DD5E521D8AE02001F7BB6 /* IAPProduct.swift in Sources */,


### PR DESCRIPTION
Noticed that the methods used to take a photo were deprecated.
It's always best to update those methods because in the next release, they may not be usable anymore.
Removed a bit of extra work that was being done during every image capture.
Cleaned up code a bit and added guards to avoid possible app crashing due to force unwrapping.